### PR TITLE
Use peerDependencies for earlgrey and tweak version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "webpack"
   ],
   "dependencies": {
-    "earlgrey": "0.0.11",
     "loader-utils": "^0.2.10"
+  },
+  "peerDependencies": {
+    "earlgrey": "^0.0"
   }
 }


### PR DESCRIPTION
In Webpack, it's considered best practice to [put the wrapped library in `peerDependencies`](http://webpack.github.io/docs/how-to-write-a-loader.html#use-a-library-as-peerdependencies-when-they-wrap-it), so the loader doesn't need to be updated with every upstream update of the wrapped library. The version range should also be reasonably open; Earl Grey is at v0.0.13 (at this writing), but earlgrey-loader is locked to v0.0.11.

This moves `earlgrey` to peerDependencies, and changes the version range to `^0.0` so it will allow all 0.0.x versions.
